### PR TITLE
fix/moveFinderServiceToServiceDirectory: Move FinderHelper class from…

### DIFF
--- a/src/Services/Filter/CachedFilterManager.php
+++ b/src/Services/Filter/CachedFilterManager.php
@@ -9,16 +9,16 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
-use Meius\LaravelFilter\Helpers\FinderHelper;
+use Meius\LaravelFilter\Services\FinderService;
 
 class CachedFilterManager extends FilterManager
 {
     public function __construct(
-        protected FinderHelper $splFileInfoHelper,
+        protected FinderService $finderService,
         protected Filesystem $filesystem,
         private FilterManager $filterManager
     ) {
-        parent::__construct($splFileInfoHelper);
+        parent::__construct($finderService);
     }
 
     #[\Override]

--- a/src/Services/Filter/FilterManager.php
+++ b/src/Services/Filter/FilterManager.php
@@ -10,13 +10,13 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Meius\LaravelFilter\Filters\FilterInterface;
-use Meius\LaravelFilter\Helpers\FinderHelper;
+use Meius\LaravelFilter\Services\FinderService;
 use ReflectionClass;
 use ReflectionException;
 
 class FilterManager implements FilterManagerInterface
 {
-    public function __construct(protected FinderHelper $splFileInfoHelper)
+    public function __construct(protected FinderService $finderService)
     {
         //
     }
@@ -30,8 +30,8 @@ class FilterManager implements FilterManagerInterface
 
     public function filters(): Generator
     {
-        foreach ($this->splFileInfoHelper->configureFinderFiles($this->baseFilterDirectory()) as $file) {
-            $filter = $this->splFileInfoHelper->getNamespace($file);
+        foreach ($this->finderService->configureFinderFiles($this->baseFilterDirectory()) as $file) {
+            $filter = $this->finderService->getNamespace($file);
 
             if ($this->isValidFilterClass($filter)) {
                 yield new $filter();

--- a/src/Services/FinderService.php
+++ b/src/Services/FinderService.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Meius\LaravelFilter\Helpers;
+namespace Meius\LaravelFilter\Services;
 
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FinderHelper
+class FinderService
 {
     public function __construct(private Finder $finder)
     {

--- a/src/Services/ModelManager.php
+++ b/src/Services/ModelManager.php
@@ -6,9 +6,8 @@ namespace Meius\LaravelFilter\Services;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
-use Meius\LaravelFilter\Helpers\FinderHelper;
-use SplFileInfo;
 use ReflectionClass;
+use SplFileInfo;
 
 class ModelManager
 {
@@ -16,7 +15,7 @@ class ModelManager
     private static array $reflectionClassCache = [];
 
     public function __construct(
-        private FinderHelper $finderHelper
+        private FinderService $finderService
     ) {
         //
     }
@@ -31,9 +30,9 @@ class ModelManager
         $models = [];
 
         /** @var SplFileInfo $file */
-        foreach ($this->finderHelper->configureFinderFiles(App::path()) as $file) {
+        foreach ($this->finderService->configureFinderFiles(App::path()) as $file) {
             try {
-                $className = $this->finderHelper->getNamespace($file);
+                $className = $this->finderService->getNamespace($file);
             } catch (\RuntimeException) {
                 continue;
             }

--- a/tests/Unit/Services/FinderServiceTest.php
+++ b/tests/Unit/Services/FinderServiceTest.php
@@ -2,30 +2,30 @@
 
 declare(strict_types=1);
 
-namespace Meius\LaravelFilter\Tests\Unit\Helpers;
+namespace Meius\LaravelFilter\Tests\Unit\Services;
 
-use Meius\LaravelFilter\Helpers\FinderHelper;
+use Meius\LaravelFilter\Services\FinderService;
 use Meius\LaravelFilter\Tests\TestCase;
 use Mockery\MockInterface;
 use RuntimeException;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FinderHelperTest extends TestCase
+class FinderServiceTest extends TestCase
 {
     public function testThrowsExceptionWhenFileIsNotReadable(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('File is not readable.');
 
-        $this->getFinderHelper()->getNamespace($this->getFile());
+        $this->getFinderService()->getNamespace($this->getFile());
     }
 
-    private function getFinderHelper(): FinderHelper
+    private function getFinderService(): FinderService
     {
-        /** @var FinderHelper $finderHelper */
-        $finderHelper = $this->app->make(FinderHelper::class);
+        /** @var FinderService $finderService */
+        $finderService = $this->app->make(FinderService::class);
 
-        return $finderHelper;
+        return $finderService;
     }
 
     private function getFile(): SplFileInfo|MockInterface

--- a/tests/Unit/Services/ModelManagerTest.php
+++ b/tests/Unit/Services/ModelManagerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Meius\LaravelFilter\Tests\Unit\Services;
 
-use Meius\LaravelFilter\Helpers\FinderHelper;
+use Meius\LaravelFilter\Services\FinderService;
 use Meius\LaravelFilter\Services\ModelManager;
 use Meius\LaravelFilter\Tests\Support\Models\Comment;
 use Meius\LaravelFilter\Tests\Support\Models\Post;
@@ -43,7 +43,7 @@ class ModelManagerTest extends TestCase
     public function testModelDoesNotExist(): void
     {
         $this->moveModels();
-        $this->mock(FinderHelper::class, function (MockInterface $mock): void {
+        $this->mock(FinderService::class, function (MockInterface $mock): void {
             $mock->shouldReceive('configureFinderFiles')
                 ->andReturn(
                     Finder::create()


### PR DESCRIPTION
… Helpers to Services The FinderService class has been relocated from the Helpers directory to the Services directory to better reflect its purpose and improve the project structure.